### PR TITLE
Fix accepted-retrospective placeholder

### DIFF
--- a/_pages/03_ar_placeholder.md
+++ b/_pages/03_ar_placeholder.md
@@ -1,6 +1,6 @@
 ---
 layout: page 
-permalink: /accepted_retrospectives
+permalink: /accepted_retrospectives/index.html
 title: Accepted Retrospectives
 ---
 


### PR DESCRIPTION
For some obscure reason the placeholder was not taking precedence when
tested locally but it did when deployed on github.

The permalink of the placeholder is now set to /accepted_retrospectives/index.html
so that it links to the proper page from the header.